### PR TITLE
Set Content-type for audio files to audio/

### DIFF
--- a/plugin/server.py
+++ b/plugin/server.py
@@ -44,10 +44,10 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
 
         if audio_file.endswith(".mp3"):
             self.send_response(200)
-            self.send_header("Content-type", "text/mpeg")
+            self.send_header("Content-type", "audio/mpeg")
         elif audio_file.endswith(".aac"):
             self.send_response(200)
-            self.send_header("Content-type", "text/aac")
+            self.send_header("Content-type", "audio/aac")
         else:
             self.send_response(400)
             return
@@ -63,10 +63,10 @@ class LocalAudioHandler(http.server.SimpleHTTPRequestHandler):
         """
         if file_path.endswith(".mp3"):
             self.send_response(200)
-            self.send_header("Content-type", "text/mpeg")
+            self.send_header("Content-type", "audio/mpeg")
         elif file_path.endswith(".aac"):
             self.send_response(200)
-            self.send_header("Content-type", "text/aac")
+            self.send_header("Content-type", "audio/aac")
         else:
             self.send_response(400)
             return


### PR DESCRIPTION
NHK audio files are stored in .aac format, but I noticed that when making a card with them, the audio files get renamed to a .mp3 extension (without doing any conversion). The audio still plays in the desktop Anki app, but raises an error in the iphone app.

I tracked this behavior down to two issues, one in the yomichan repo (FooSoft/yomichan#2302) and this one here.